### PR TITLE
API Documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,10 @@ gem 'devise'
 # Authorization
 gem 'cancancan'
 
+# Api documentation
+
+gem 'rswag'
+
 # Use postgresql as the database for Active Record
 gem 'pg', '~> 1.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,8 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.6.3)
+    json-schema (3.0.0)
+      addressable (>= 2.8)
     loofah (2.20.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -209,6 +211,20 @@ GEM
       rspec-mocks (~> 3.11)
       rspec-support (~> 3.11)
     rspec-support (3.12.0)
+    rswag (2.8.0)
+      rswag-api (= 2.8.0)
+      rswag-specs (= 2.8.0)
+      rswag-ui (= 2.8.0)
+    rswag-api (2.8.0)
+      railties (>= 3.1, < 7.1)
+    rswag-specs (2.8.0)
+      activesupport (>= 3.1, < 7.1)
+      json-schema (>= 2.2, < 4.0)
+      railties (>= 3.1, < 7.1)
+      rspec-core (>= 2.14)
+    rswag-ui (2.8.0)
+      actionpack (>= 3.1, < 7.1)
+      railties (>= 3.1, < 7.1)
     rubocop (1.49.0)
       json (~> 2.3)
       parallel (~> 1.10)
@@ -283,6 +299,7 @@ DEPENDENCIES
   rails (~> 7.0.4, >= 7.0.4.3)
   rails-controller-testing
   rspec-rails
+  rswag
   rubocop (>= 1.0, < 2.0)
   selenium-webdriver
   sprockets-rails

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,6 +42,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,14 @@
+Rswag::Api.configure do |c|
+
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.swagger_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,16 @@
+Rswag::Ui.configure do |c|
+
+  # List the Swagger endpoints that you want to be documented through the
+  # swagger-ui. The first parameter is the path (absolute or relative to the UI
+  # host) to the corresponding endpoint and the second is a title that will be
+  # displayed in the document selector.
+  # NOTE: If you're using rspec-api to expose Swagger files
+  # (under swagger_root) as JSON or YAML endpoints, then the list below should
+  # correspond to the relative paths for those endpoints.
+
+  c.swagger_endpoint '/api-docs/v1/swagger.yaml', 'API V1 Docs'
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
   devise_for :users
   root "users#index"
   resources :users, only: [:index, :show] do 

--- a/spec/integration/comments_spec.rb
+++ b/spec/integration/comments_spec.rb
@@ -1,0 +1,41 @@
+require 'swagger_helper'
+
+RSpec.describe 'Comments API', type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { User.create!(name: 'John', email: 'john@gmail.com', password: 'password') }
+  let(:post) { Post.create!(author: user, title: 'Title', text: 'Text') }
+
+  before do
+    user.confirmed_at = Time.now
+    sign_in user
+  end
+
+  path '/users/{user_id}/posts/{id}/comments' do
+    get 'Lists all comments of a post' do
+      tags 'Comments'
+      produces 'application/json'
+      parameter name: :user_id, in: :path, type: :integer
+      parameter name: :id, in: :path, type: :integer
+
+      response '200', 'all comments returned' do
+        schema type: :array,
+               items: {
+                 type: :object,
+                 properties: {
+                   id: { type: :integer },
+                   text: { type: :string },
+                   author_id: { type: :integer },
+                   post_id: { type: :integer },
+                   created_at: { type: :string },
+                   updated_at: { type: :string }
+                 },
+                 required: %w[id title text author_id created_at updated_at]
+               }
+        let(:user_id) { user.id }
+        let(:id) { post.id }
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/integration/comments_spec.rb
+++ b/spec/integration/comments_spec.rb
@@ -38,4 +38,29 @@ RSpec.describe 'Comments API', type: :request do
       end
     end
   end
+
+  path '/users/{user_id}/posts/{id}/comments' do
+    post 'Create a new comment' do
+      tags 'Comments'
+      produces 'application/json'
+      consumes 'application/json'
+      parameter name: :user_id, in: :path, type: :integer
+      parameter name: :id, in: :path, type: :integer
+      parameter name: :comment_params, in: :body, schema: {
+        type: :object,
+        properties: {
+          text: { type: :string }
+        },
+        required: %w[text]
+      }
+
+      response '201', 'comment created' do
+        let(:user_id) { user.id }
+        let(:id) { post.id }
+        let(:comment_params) { { text: 'This is a test comment.' } }
+
+        run_test!
+      end
+    end
+  end
 end

--- a/spec/integration/posts_spec.rb
+++ b/spec/integration/posts_spec.rb
@@ -1,0 +1,34 @@
+require 'swagger_helper'
+
+RSpec.describe 'Posts API', type: :request do
+  let(:user) { User.create!(name: 'John', email: 'john@gmail.com', password: 'password') }
+
+  path '/users/{id}/posts.json' do
+
+    get 'Lists all posts of a user' do
+      tags 'Posts'
+      produces 'application/json'
+      parameter name: :id, in: :path, type: :integer
+
+      response '200', 'all posts returned' do
+        schema type: :array,
+               items: {
+                 type: :object,
+                 properties: {
+                   id: { type: :integer },
+                   title: { type: :string },
+                   text: { type: :string },
+                   comments_counter: { type: :integer },
+                   likes_counter: { type: :integer },
+                   author_id: { type: :integer },
+                   created_at: { type: :string },
+                   updated_at: { type: :string }
+                 },
+                 required: ['id', 'title', 'text', 'author_id', 'created_at', 'updated_at']
+               }
+        let(:id) { user.id }
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.configure do |config|
+  # Specify a root folder where Swagger JSON files are generated
+  # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
+  # to ensure that it's configured to serve Swagger from the same folder
+  config.swagger_root = Rails.root.join('swagger').to_s
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+  # be generated at the provided relative path under swagger_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a swagger_doc tag to the
+  # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
+  config.swagger_docs = {
+    'v1/swagger.yaml' => {
+      openapi: '3.0.1',
+      info: {
+        title: 'API V1',
+        version: 'v1'
+      },
+      paths: {},
+      servers: [
+        {
+          url: 'https://{defaultHost}',
+          variables: {
+            defaultHost: {
+              default: 'www.example.com'
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  # Specify the format of the output Swagger file when running 'rswag:specs:swaggerize'.
+  # The swagger_docs configuration option has the filename including format in
+  # the key, this may want to be changed to avoid putting yaml in json files.
+  # Defaults to json. Accepts ':json' and ':yaml'.
+  config.swagger_format = :yaml
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1,0 +1,55 @@
+---
+openapi: 3.0.1
+info:
+  title: API V1
+  version: v1
+paths:
+  "/users/{id}/posts.json":
+    get:
+      summary: Lists all posts of a user
+      tags:
+      - Posts
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: all posts returned
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    title:
+                      type: string
+                    text:
+                      type: string
+                    comments_counter:
+                      type: integer
+                    likes_counter:
+                      type: integer
+                    author_id:
+                      type: integer
+                    created_at:
+                      type: string
+                    updated_at:
+                      type: string
+                  required:
+                  - id
+                  - title
+                  - text
+                  - author_id
+                  - created_at
+                  - updated_at
+servers:
+- url: https://{defaultHost}
+  variables:
+    defaultHost:
+      default: www.example.com

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -4,7 +4,7 @@ info:
   title: API V1
   version: v1
 paths:
-  "/users/{id}/posts.json":
+  "/users/{id}/posts":
     get:
       summary: Lists all posts of a user
       tags:
@@ -48,6 +48,32 @@ paths:
                   - author_id
                   - created_at
                   - updated_at
+    post:
+      summary: Create a new post
+      tags:
+      - Posts
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+      responses:
+        '201':
+          description: post created
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                text:
+                  type: string
+              required:
+              - title
+              - text
 servers:
 - url: https://{defaultHost}
   variables:

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -4,6 +4,51 @@ info:
   title: API V1
   version: v1
 paths:
+  "/users/{user_id}/posts/{id}/comments":
+    get:
+      summary: Lists all comments of a post
+      tags:
+      - Comments
+      parameters:
+      - name: user_id
+        in: path
+        required: true
+        schema:
+          type: integer
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: all comments returned
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    text:
+                      type: string
+                    author_id:
+                      type: integer
+                    post_id:
+                      type: integer
+                    created_at:
+                      type: string
+                    updated_at:
+                      type: string
+                  required:
+                  - id
+                  - title
+                  - text
+                  - author_id
+                  - created_at
+                  - updated_at
   "/users/{id}/posts":
     get:
       summary: Lists all posts of a user

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -49,6 +49,34 @@ paths:
                   - author_id
                   - created_at
                   - updated_at
+    post:
+      summary: Create a new comment
+      tags:
+      - Comments
+      parameters:
+      - name: user_id
+        in: path
+        required: true
+        schema:
+          type: integer
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+      responses:
+        '201':
+          description: comment created
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                text:
+                  type: string
+              required:
+              - text
   "/users/{id}/posts":
     get:
       summary: Lists all posts of a user


### PR DESCRIPTION
# Generating documentation for API endpoints
The following changes are made in this branch:
- Added integration tests for post endpoints
- Added integration tests for comment endpoints
- Generated documentation using `rswag`